### PR TITLE
fix: working example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,25 @@ While testing the happy path is a good start, you might also want to verify that
 
 Example:
 
+`tests/default.nix`
 ``` nix
-  testCatchWrongMessage = {
-    expr = throw "I give up";
+{
+  testCatchMessage = {
+    expr = throw "10 instead of 5";
     expectedError.type = "ThrownError";
-    expectedError.msg = "\\d+ errors";
+    expectedError.msg = "\\d+ instead of 5";
+  };
+}
 ```
+->
+```
+✅ testCatchMessage
+
+🎉 1/1 successful
+```
+
+
+> Note: Regular expression like the one above are supported
 
 ### Supported error types
 


### PR DESCRIPTION
This pull request updates the error example in the readme.
The previous example was a good test case, but it shouldn't be the main focus. I'd expect examples in the readme to work right away.
