### PR TITLE
fix: count, allow overridable nix input for flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -17,6 +33,44 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "lowdown-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "lowdown-src": "lowdown-src",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1694451812,
+        "narHash": "sha256-bsnHYinsv1HRKqcAO23KD2fn5COzc/CmakRJ8i6dZKw=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "d98337d18f23690adf416f0ae2ff86d9d9015118",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nix",
         "type": "github"
       }
     },
@@ -42,11 +96,43 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688951312,
-        "narHash": "sha256-0oG4uv60m5+oOMqgYYQ3ao3OK3YP3n3t7nWFtuyR/uQ=",
+        "lastModified": 1670461440,
+        "narHash": "sha256-jy1LB8HOMKGJEGXgzFRLDU1CBGL0/LlkolgnqIsF0D8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2a5f6cac357616d2596167d0631b4ca729e9a3ea",
+        "rev": "04a75b2eecc0acf6239acf9dd04485ff8d14f425",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1694515786,
+        "narHash": "sha256-ogQaPNtaYHEZVG2nsLC8TZT7BhSPcG+lAtFIZZwEQlg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9f9d9a6db03c1d78fe7b3030def18b625827382f",
         "type": "github"
       },
       "original": {
@@ -59,8 +145,9 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
+        "nix": "nix",
         "nix-github-actions": "nix-github-actions",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "treefmt-nix": "treefmt-nix"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,7 @@
   inputs.treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
   inputs.nix-github-actions.url = "github:nix-community/nix-github-actions";
   inputs.nix-github-actions.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.nix.url = "github:NixOS/nix/master";
 
   outputs = inputs @ { flake-parts, nix-github-actions, ... }:
     let
@@ -26,12 +27,12 @@
           };
         };
 
-        perSystem = { pkgs, self', ... }:
+        perSystem = { pkgs, self', inputs', ... }:
           let
             inherit (pkgs) stdenv;
             drvArgs = {
               srcDir = self;
-              nix = pkgs.nixUnstable;
+              nix = inputs'.nix.packages.nix;
             };
           in
           {

--- a/src/nix-unit.cc
+++ b/src/nix-unit.cc
@@ -246,8 +246,8 @@ static TestResults runTests(ref<EvalState> state, Bindings &autoArgs) {
     // Run a single test from attrset
     const auto runTest = [&](std::vector<std::string> attrPath,
                              nix::Value *test) {
-        results.total++;
 
+            results.total++;
         std::string attr = attrPathJoin(attrPath);
 
         try {
@@ -278,12 +278,10 @@ static TestResults runTests(ref<EvalState> state, Bindings &autoArgs) {
                         << (success ? "✅" : "❌") << " " << attr << std::endl;
                 }
 
-                if (success) {
-                    results.success++;
-                } else {
+                if (!success)
                     runDiffTool("difft", printValue(*state, *expr->value),
                                 printValue(*state, *expected->value));
-                }
+                
 
             } else if (expectedError) {
                 state->forceAttrs(*expectedError->value, noPos,
@@ -368,7 +366,7 @@ static TestResults runTests(ref<EvalState> state, Bindings &autoArgs) {
                 throw EvalError(
                     "Missing attrset keys 'expected' or 'expectedError'");
             }
-
+            
             if (success) {
                 results.success++;
             }
@@ -426,15 +424,16 @@ int main(int argc, char **argv) {
 
         /* Prevent access to paths outside of the Nix search path and
            to the environment. */
-        evalSettings.restrictEval = false;
+        // evalSettings.restrictEval = false;
 
         /* When building a flake, use pure evaluation (no access to
            'getEnv', 'currentSystem' etc. */
-        if (myArgs.impure) {
-            evalSettings.pureEval = false;
-        } else if (myArgs.flake) {
-            evalSettings.pureEval = true;
-        }
+        
+        // if (myArgs.impure) {
+        //     evalSettings.pureEval = false;
+        // } else if (myArgs.flake) {
+        //     evalSettings.pureEval = true;
+        // }
 
         if (myArgs.releaseExpr == "")
             throw UsageError("no expression specified");


### PR DESCRIPTION
- Fixes: #10 
- Adds overridable nix input.

I removed the `evalSettings.restrictEval = false;` because i cannot compile the newer nix versions with it.

Feel free to push changes to this branch as needed.