### PR TITLE
packaging: Reduce rebuilds with accurate source filter

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,6 @@
 {
   stdenv,
   lib,
-  srcDir ? null,
   boost,
   clang-tools,
   cmake,
@@ -15,14 +14,20 @@
 }:
 
 let
-  filterMesonBuild = builtins.filterSource (
-    path: type: type != "directory" || baseNameOf path != "build"
-  );
+  inherit (lib) fileset;
+  src = lib.fileset.toSource {
+    fileset = files;
+    root = ./.;
+  };
+  files = fileset.unions [
+    ./src
+    ./meson.build
+  ];
 in
 stdenv.mkDerivation {
   pname = "nix-unit";
   version = "2.24.1";
-  src = if srcDir == null then filterMesonBuild ./. else srcDir;
+  inherit src;
   buildInputs = [
     nlohmann_json
     nix

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,6 @@
         let
           inherit (pkgs) stdenv;
           drvArgs = {
-            srcDir = self;
             nix = pkgs.nixVersions.nix_2_24;
           };
         in


### PR DESCRIPTION
This removes `srcDir`, which is not needed. It is ok to refer to local files.

The filter is "positive" or inclusion-based, because exclusion-based filters tend to include too much, causing unnecessary rebuilds, and they require more maintenance as files are added. Sometimes it's a trade-off with list size, but that's not even the case here.

This commit assumes the `default.nix` is only accessed through flakes. Otherwise, it'd be good to filter out `build` again. I have not implemented that, because I found no other traces of non-flake usage.