### PR TITLE
fix: initialize flake library

### DIFF
--- a/src/nix-unit.cc
+++ b/src/nix-unit.cc
@@ -427,6 +427,7 @@ int main(int argc, char **argv) {
     return handleExceptions(argv[0], [&]() {
         initNix();
         initGC();
+        nix::flake::initLib(flakeSettings);
 
         myArgs.parseCmdline(argvToStrings(argc, argv));
 


### PR DESCRIPTION
```
nix::flake::initLib(flakeSettings);
```

is required to initialize _at least_ the `getFlake` builtin, which is otherwise entirely missing from the evaluator.

Note that in newer Nix versions, this is apparently done via

```
flakeSettings::configureEvalSettings(nix::EvalSettings & evalSettings)
```

instead.