### PR TITLE
feat: enable pipe-operators experimental features in flake-parts

### DIFF
--- a/lib/modules/flake/system.nix
+++ b/lib/modules/flake/system.nix
@@ -119,7 +119,7 @@ in
               echo "Running tests for " ${lib.escapeShellArg system}
               nix-unit \
                 --show-trace \
-                --extra-experimental-features flakes \
+                --extra-experimental-features "flakes pipe-operators" \
                 --accept-flake-config \
                 ${lib.concatStringsSep "\\\n  " (lib.mapAttrsToList overrideArg config.nix-unit.inputs)} \
                 --flake ${self}#tests.systems.${system} \


### PR DESCRIPTION
There are a few ways to make it possible to enable pipe-operators:
- always enable pipe-operators
- make a flake-parts option for users to set experimental features

I choose the simplest one which should have no negative effects.  I am willing to switch to another approach if needed.